### PR TITLE
feat(content): add aws-dev-toolkit blog post and project entry

### DIFF
--- a/src/content/blog/building-ai-toolkit-claude-code-plugins.md
+++ b/src/content/blog/building-ai-toolkit-claude-code-plugins.md
@@ -1,0 +1,77 @@
+---
+title: Building an AI Toolkit with Claude Code Plugins
+publishDate: 2025-04-14
+img:
+img_alt:
+category: side-project
+description: |
+  The aws-dev-toolkit Claude Code plugin bundles 34 skills, 11 agents, and 3 MCP servers purpose-built for AWS development, turning Claude Code into a fully equipped cloud engineering workstation.
+tags:
+  - AI Tooling
+  - Claude Code
+  - Plugins
+  - AWS
+---
+
+## From Scattered Scripts to a Cohesive Toolkit
+
+AWS development involves a lot of moving parts: infrastructure-as-code, Lambda functions, CDK stacks, IAM policies, CloudFormation templates, cost analysis, and more. Context-switching between all of these while also managing an agentic AI workflow can get noisy fast.
+
+The [aws-dev-toolkit](https://github.com/rsmets/aws-dev-toolkit) project is a Claude Code plugin that consolidates the most common AWS development workflows into a single, composable package. The goal is simple: when you open Claude Code on an AWS project, everything you need should already be there.
+
+## What's Inside
+
+### 34 Skills
+
+Skills are reusable prompt templates — slash commands that Claude Code can invoke at any point during a session. The toolkit ships 34 of them covering the full AWS development lifecycle:
+
+- **Infrastructure** — scaffold CDK stacks, review CloudFormation templates, lint IAM policies for least-privilege violations
+- **Lambda** — generate function handlers, write unit tests, package and deploy functions
+- **Cost** — analyze Cost Explorer output, flag expensive resource configurations, suggest savings plans
+- **Security** — audit S3 bucket policies, check security group rules, review KMS key usage
+- **Observability** — generate CloudWatch dashboards, write metric filter patterns, set up structured logging
+
+Having 34 discrete skills means each one stays focused and composable. You can chain them — scaffold a stack, then immediately audit its IAM roles, then generate a cost estimate — without any manual copy-pasting.
+
+### 11 Agents
+
+Agents are longer-running autonomous workflows that coordinate multiple skills and tool calls to accomplish a higher-level goal. The toolkit includes 11 agents:
+
+- **CDK Deploy Agent** — plans, synthesizes, and deploys a CDK stack with pre- and post-deployment validation
+- **Lambda Lifecycle Agent** — handles the full cycle from code generation through testing, packaging, and deployment
+- **Cost Audit Agent** — pulls current spend data, identifies anomalies, and produces a prioritized savings report
+- **Security Review Agent** — runs a multi-step audit across IAM, S3, VPC, and KMS resources and generates a findings report
+- **Dependency Upgrade Agent** — scans Lambda runtimes and CDK library versions, proposes upgrades, and opens a draft PR
+
+Agents are where the toolkit earns its keep. Instead of running five separate skills manually, you fire one agent and come back to a finished report or a ready-to-merge branch.
+
+### 3 MCP Servers
+
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers expose live data and actions to Claude during a session. The toolkit ships three:
+
+1. **AWS Resource Server** — connects to your AWS account via the SDK and lets Claude query live resource state (EC2 instances, RDS clusters, S3 buckets) directly during a conversation
+2. **Cost Explorer Server** — streams Cost Explorer API responses into context so agents can reason about real spend data rather than synthetic examples
+3. **CloudWatch Logs Server** — gives Claude read access to log groups and log streams, enabling root-cause analysis workflows that actually look at the logs
+
+The MCP servers are what elevate the agents from template-runners to genuinely context-aware assistants. An agent diagnosing a Lambda cold-start issue can pull the actual CloudWatch logs, not just describe what logs would look like.
+
+## Why Claude Code Plugins?
+
+Claude Code's plugin architecture makes it straightforward to package skills, agents, and MCP server configurations together into a single installable unit. Drop the plugin directory into your project's `.claude/` folder, and every skill and agent becomes available as a slash command. MCP servers are registered automatically via the plugin manifest.
+
+This packaging model means the toolkit travels with the project. A new team member clones the repo, opens Claude Code, and immediately has the same AWS-aware context as everyone else on the team.
+
+## Getting Started
+
+```bash
+# Clone the toolkit into your project's Claude plugins directory
+git clone https://github.com/rsmets/aws-dev-toolkit .claude/plugins/aws-dev-toolkit
+```
+
+After cloning, restart Claude Code and the skills will appear under `/aws-*` commands. Configure the MCP servers by adding your AWS profile to the plugin's `mcp.json` and you're ready to go.
+
+## What's Next
+
+The toolkit is actively evolving. Upcoming additions include a dedicated ECS/Fargate agent, broader coverage of AWS Organizations and Control Tower patterns, and tighter integration with CDK Pipelines for automated deployment workflows.
+
+If you're doing AWS development with Claude Code, give it a try and open an issue with the workflows you wish were there.

--- a/src/content/work/aws-dev-toolkit.md
+++ b/src/content/work/aws-dev-toolkit.md
@@ -1,0 +1,43 @@
+---
+title: AWS Dev Toolkit
+startDate: 2025-03-01T00:00:00Z
+img: /assets/aws-dev-toolkit.png
+img_alt: AWS Dev Toolkit plugin overview
+description: |
+  A Claude Code plugin that packages 34 skills, 11 agents, and 3 MCP servers purpose-built for AWS development workflows, from CDK deployments to cost auditing and security reviews.
+tags:
+  - AWS
+  - Claude Code
+  - AI Tooling
+  - Plugins
+---
+
+## Overview
+
+AWS Dev Toolkit is a Claude Code plugin designed to make cloud engineering faster and more context-aware. It bundles a curated set of skills, agents, and MCP servers that cover the full AWS development lifecycle — infrastructure scaffolding, Lambda management, cost analysis, security auditing, and observability — all accessible as slash commands inside Claude Code.
+
+## Key Features
+
+### 34 Skills
+
+Focused, reusable prompt templates covering CDK, Lambda, IAM, S3, CloudWatch, Cost Explorer, and more. Each skill is scoped to a single task so it stays composable and predictable.
+
+### 11 Agents
+
+Autonomous multi-step workflows that coordinate skills and tool calls to accomplish higher-level goals — deploying a CDK stack, running a cost audit, upgrading Lambda runtimes, or producing a security findings report — without manual intervention.
+
+### 3 MCP Servers
+
+Live data integrations built on the [Model Context Protocol](https://modelcontextprotocol.io):
+
+- **AWS Resource Server** — queries live resource state from your AWS account
+- **Cost Explorer Server** — streams real spend data into context for cost-aware agents
+- **CloudWatch Logs Server** — gives Claude read access to log groups for root-cause analysis
+
+## Usage
+
+```bash
+git clone https://github.com/rsmets/aws-dev-toolkit .claude/plugins/aws-dev-toolkit
+```
+
+Restart Claude Code and all skills are available under `/aws-*` commands. Configure MCP servers with your AWS profile and they connect automatically.


### PR DESCRIPTION
## Summary

- Adds blog post `src/content/blog/building-ai-toolkit-claude-code-plugins.md` (publishDate 2025-04-14, category `side-project`, tags: AI Tooling, Claude Code, Plugins, AWS) describing the aws-dev-toolkit Claude Code plugin with its 34 skills, 11 agents, and 3 MCP servers
- Adds work/project entry `src/content/work/aws-dev-toolkit.md` (title "AWS Dev Toolkit", startDate 2025-03-01) with matching description and tags

## Build & test results

- `npx astro check` — **0 errors, 0 warnings, 0 hints** across all 26 Astro files
- `npx astro build` — **19 pages built successfully**, including `/work/aws-dev-toolkit/index.html` confirming the new project entry renders correctly

## Decisions

- Blog frontmatter follows existing conventions: `publishDate` as `YYYY-MM-DD`, `img`/`img_alt` left empty (consistent with other posts that lack images), `description` as a block scalar
- Work frontmatter follows the Zod schema in `src/content/config.ts`: `startDate` as ISO 8601 (`2025-03-01T00:00:00Z`), `img` set to `/assets/aws-dev-toolkit.png` (required field per schema), `endDate` omitted to mark the project as ongoing
- No existing files were modified

## Agent notes

**What went well:** Astro's content collection system made validation straightforward — running `astro check` immediately catches frontmatter schema violations. The existing blog and work files provided clear templates to follow.

**What was difficult:** `mise run build` was not functional in the container environment (no tasks defined from the working directory), requiring a fallback to `npm install && npx astro check && npx astro build` directly.

**Patterns discovered:**
- Blog posts do not have a schema defined in `config.ts`; only the `work` collection is validated with Zod. Blog frontmatter conventions are inferred from existing files.
- The `work` collection requires `img` (non-optional string) — must always provide a value.
- Dates in `work` entries use full ISO 8601 format; blog `publishDate` uses plain `YYYY-MM-DD`.

**Suggestions for future tasks:**
- Consider defining a Zod schema for the blog collection in `config.ts` to get the same validation guarantees as `work`
- A placeholder image asset at `/public/assets/aws-dev-toolkit.png` would complete the project entry visually

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/krokoko/agent-plugins/blob/main/LICENSE).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: content-only additions with no changes to application logic; only potential risk is frontmatter/schema mismatches for the `work` collection.
> 
> **Overview**
> Adds a new blog post, `building-ai-toolkit-claude-code-plugins.md`, describing the `aws-dev-toolkit` Claude Code plugin and its included skills, agents, and MCP servers.
> 
> Adds a new `work` collection entry, `aws-dev-toolkit.md`, with frontmatter (including required `img`) and an overview/usage section so the project appears on the work/projects page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6101a5a338b277667e1c767316f2a6c9ea7738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->