### PR TITLE
Blog: x402 trust layer and agent micropayments

### DIFF
--- a/src/content/blog/trust-layer-agent-economy.md
+++ b/src/content/blog/trust-layer-agent-economy.md
@@ -5,7 +5,7 @@ img:
 img_alt:
 category: technology
 description: |
-  Autonomous agents are starting to pay each other on-chain. The protocols are mostly solved. The hard part—knowing who is worth transacting with—is the trust layer nobody has built yet.
+  Autonomous agents are starting to pay each other on-chain. The protocols are mostly solved. The hard part, knowing who is worth transacting with, is the trust layer nobody has built yet.
 tags:
   - Agentic AI
   - Decentralized Identity
@@ -15,7 +15,7 @@ tags:
 
 ## The Plumbing Is Done. The Trust Isn't.
 
-For the last year the conversation around agentic commerce has been about plumbing. How do agents pay each other? [x402](https://www.x402.org/) resurrected the dormant HTTP 402 status code into a stablecoin payment protocol, won itself a Linux Foundation home, and pulled in basically everyone who matters—Visa, Mastercard, Stripe, Google, AWS, Coinbase, Circle. Google's AP2 adopted x402 as its crypto rail rather than competing with it. The standards war is effectively over.
+For the last year the conversation around agentic commerce has been about plumbing. How do agents pay each other? [x402](https://www.x402.org/) resurrected the dormant HTTP 402 status code into a stablecoin payment protocol, won itself a Linux Foundation home, and pulled in basically everyone who matters: Visa, Mastercard, Stripe, Google, AWS, Coinbase, Circle. Google's AP2 adopted x402 as its crypto rail rather than competing with it. The standards war is effectively over.
 
 So we can now make an agent pay another agent for an API call without a human in the loop. Great. Here is the question almost nobody is answering: **how does the buyer agent know the seller is any good?**
 
@@ -23,9 +23,9 @@ That sounds small. It is the entire game.
 
 ## A Decade of Watching Identity Marketplaces Die
 
-I have a particular allergy to this problem because I have watched its cousin fail repeatedly. Years ago, during my graduate work in information security, I wrote a [white paper on decentralized access control](/work/decentralized-access-control)—the idea that users should own their identities outright rather than renting trust from whoever happens to operate the server. The motivating realization was uncomfortable: while running the backend for an access control startup, I could impersonate any user in our system and quietly rewrite the logs. The whole edifice rested on trusting the operator.
+I have a particular allergy to this problem because I have watched its cousin fail repeatedly. Years ago, during my graduate work in information security, I wrote a [white paper on decentralized access control](/work/decentralized-access-control), arguing that users should own their identities outright rather than renting trust from whoever happens to operate the server. The motivating realization was uncomfortable: while running the backend for an access control startup, I could impersonate any user in our system and quietly rewrite the logs. The whole edifice rested on trusting the operator.
 
-The decentralized-identity world's answer was Verifiable Credentials and DIDs—cryptographically signed claims that you carry and present yourself. Beautiful primitives. And for human identity, they mostly died on the vine. Not because the cryptography was wrong, but because of **cold-start**. Nobody issues credentials before anybody verifies them, verifiers won't pay for coverage that doesn't exist yet, and everyone stalls in a standoff waiting for the other side to move first.
+The decentralized-identity world's answer was Verifiable Credentials and DIDs, cryptographically signed claims that you carry and present yourself. Beautiful primitives. And for human identity, they mostly died on the vine. Not because the cryptography was wrong, but because of **cold-start**. Nobody issues credentials before anybody verifies them, verifiers won't pay for coverage that doesn't exist yet, and everyone stalls in a standoff waiting for the other side to move first.
 
 I bring this up because the agent economy quietly breaks that standoff, and most people haven't noticed why.
 
@@ -35,27 +35,27 @@ Here is the thing that makes agent reputation genuinely different from human rep
 
 For the first time, you can bootstrap a reputation graph by *mining what already happened* instead of begging a network into existence. That is a structural escape hatch from the cold-start trap that buried a decade of identity ventures. It genuinely excites me.
 
-But—and this is where I want to be the person who tells you the unsexy truth—the chain only sees half of what matters.
+But the chain only sees half of what matters, and this is where I want to be the person who tells you the unsexy truth.
 
 ## The Quantity/Quality Gap Nobody Wants to Talk About
 
 On-chain data tells you *quantity*. How much did this endpoint settle? With how many distinct counterparties? How old is the wallet? What's the refund rate? Real signal, all of it.
 
-What the chain cannot tell you is *quality*. **Did the API actually return good data?** Was the response correct, or was it confidently wrong? The settlement event fires the moment money moves—the protocol is "settle-and-done" by design, and the chain can't roll back a delivered HTTP response. So the single most important question—*was this service any good?*—lives entirely off-chain.
+What the chain cannot tell you is *quality*. **Did the API actually return good data?** Was the response correct, or was it confidently wrong? The settlement event fires the moment money moves. The protocol is "settle-and-done" by design, and the chain can't roll back a delivered HTTP response. So the single most important question, *was this service any good?*, lives entirely off-chain.
 
-This matters because the easy, seductive version of agent reputation is "count the transactions and rank them." And counting transactions is *exactly* what an adversary optimizes against. At its peak, something like half of all x402 volume was wash-trading—wallets paying themselves to manufacture the appearance of activity. The adversary isn't hypothetical and arriving later. **The adversary is already here, and it showed up before the legitimate customers did.**
+This matters because the easy, seductive version of agent reputation is "count the transactions and rank them." And counting transactions is *exactly* what an adversary optimizes against. At its peak, something like half of all x402 volume was wash-trading: wallets paying themselves to manufacture the appearance of activity. The adversary isn't hypothetical and arriving later. **The adversary is already here, and it showed up before the legitimate customers did.**
 
-Any reputation system that scores volume is scoring the precise thing fraud is best at faking. The hard, valuable work is everything the chain doesn't give you for free: clustering sybil wallets, fingerprinting spam farms, and—the part that costs real money—actually probing services to see if they deliver. Quality measurement is adversarial security operations, not a database query. Anyone who tells you on-chain data alone solves agent trust is selling the easy half.
+Any reputation system that scores volume is scoring the precise thing fraud is best at faking. The hard, valuable work is everything the chain doesn't give you for free: clustering sybil wallets, fingerprinting spam farms, and the part that costs real money, actually probing services to see if they deliver. Quality measurement is adversarial security operations, not a database query. Anyone who tells you on-chain data alone solves agent trust is selling the easy half.
 
 ## Reputation You Own vs. Reputation You Rent
 
 Now the part that pulls my two careers together. Suppose you do build a credible trust signal. Where does it live?
 
-Today the most sophisticated scorer in the space is Coinbase's Bazaar, and its reputation score is *walled*—computed internally, never exposed to the caller, applied only to traffic that routes through Coinbase. That is reputation you rent. It works inside one castle and evaporates the moment you step outside it.
+Today the most sophisticated scorer in the space is Coinbase's Bazaar, and its reputation score is *walled*. It's computed internally, never exposed to the caller, applied only to traffic that routes through Coinbase. That is reputation you rent. It works inside one castle and evaporates the moment you step outside it.
 
-This is the same mistake the centralized identity world made, and it's exactly the failure mode my white paper was reacting to. A trust score that a single rail owner controls is a trust score that serves the rail owner. The instant an agent transacts across a different rail—x402 here, AP2 there, something not yet invented next year—a vendor-locked score is worthless.
+This is the same mistake the centralized identity world made, and it's exactly the failure mode my white paper was reacting to. A trust score that a single rail owner controls is a trust score that serves the rail owner. The instant an agent transacts across a different rail, x402 here, AP2 there, something not yet invented next year, a vendor-locked score is worthless.
 
-The version that actually matters is **portable**: a signed attestation the agent carries with it across rails and platforms, verifiable by anyone, owned by no one. This is, after a decade, finally the *right* application for Verifiable Credentials and DIDs. Not because the buzzwords aged well, but because the agent economy produces the one thing human identity never could—an objective behavioral history worth attaching to a portable, self-controlled identifier. The primitive was waiting for the right substrate the whole time.
+The version that actually matters is **portable**: a signed attestation the agent carries with it across rails and platforms, verifiable by anyone, owned by no one. This is, after a decade, finally the *right* application for Verifiable Credentials and DIDs. Not because the buzzwords aged well, but because the agent economy produces the one thing human identity never could, an objective behavioral history worth attaching to a portable, self-controlled identifier. The primitive was waiting for the right substrate the whole time.
 
 And notably, no single rail owner can credibly build this, because neutrality is the product. Coinbase won't trust Google's scores and Google won't trust Coinbase's. Cross-rail trust has to come from someone who isn't a rail.
 
@@ -63,10 +63,10 @@ And notably, no single rail owner can credibly build this, because neutrality is
 
 I want to close honestly, because thought leadership that only sells the upside isn't leadership.
 
-Real, non-synthetic agent commerce is still *tiny*—on the order of tens of thousands of dollars a day, with average payments around twenty cents. Reputation matters in proportion to value-at-risk, and right now the value at risk per decision is pocket change. Nobody underwrites a twenty-cent loan.
+Real, non-synthetic agent commerce is still *tiny*, on the order of tens of thousands of dollars a day, with average payments around twenty cents. Reputation matters in proportion to value-at-risk, and right now the value at risk per decision is pocket change. Nobody underwrites a twenty-cent loan.
 
-So we have a genuine chicken-and-egg: **high-value autonomous commerce won't happen until trust infrastructure exists, and trust infrastructure can't sustain itself until high-value commerce exists.** That tension is the most important fact in the entire space, and it cuts both ways. It's the reason this is hard. It's also the reason it's interesting—whoever builds the trust layer isn't just serving the market, they're a precondition for it existing at all. The catalyst and the customer are the same thing.
+So we have a genuine chicken-and-egg: **high-value autonomous commerce won't happen until trust infrastructure exists, and trust infrastructure can't sustain itself until high-value commerce exists.** That tension is the most important fact in the entire space, and it cuts both ways. It's the reason this is hard. It's also the reason it's interesting: whoever builds the trust layer isn't just serving the market, they're a precondition for it existing at all. The catalyst and the customer are the same thing.
 
-The plumbing question—*how do agents pay?*—is solved. The question that decides whether any of it amounts to a real economy is older than blockchains, older than the internet: *when a stranger offers to transact, how do you know they're worth trusting?* We just have to answer it for counterparties that spin up in milliseconds, settle irreversibly, and lie about half the time.
+The plumbing question, *how do agents pay?*, is solved. The question that decides whether any of it amounts to a real economy is older than blockchains, older than the internet: *when a stranger offers to transact, how do you know they're worth trusting?* We just have to answer it for counterparties that spin up in milliseconds, settle irreversibly, and lie about half the time.
 
 That's the layer I can't stop thinking about. The protocols were the easy part.

--- a/src/content/blog/trust-layer-agent-economy.md
+++ b/src/content/blog/trust-layer-agent-economy.md
@@ -16,6 +16,8 @@ tags:
 
 For the last year the conversation around agentic commerce has been about plumbing. How do agents pay each other? [x402](https://www.x402.org/) resurrected the dormant HTTP 402 status code into a stablecoin payment protocol, won itself a Linux Foundation home, and pulled in basically everyone who matters: Visa, Mastercard, Stripe, Google, AWS, Coinbase, Circle. Google's AP2 adopted x402 as its crypto rail rather than competing with it. The standards war is effectively over.
 
+To be honest about where attention went: since both landed around the same time last year, x402 has lived almost entirely in [MCP](/blog/mcp/)'s shadow. I get why. MCP solved connectivity—how agents reach tools and data—and the ecosystem poured its energy there. But x402 solves what commerce actually runs on: autonomous settlement. For a micro-payment-oriented agent economy—agents paying fractions of a cent per API call without a human in the loop—I think x402 will prove nearly as noteworthy as MCP did for interoperability.
+
 So we can now make an agent pay another agent for an API call without a human in the loop. Great. Here is the question almost nobody is answering: **how does the buyer agent know the seller is any good?**
 
 That sounds small. It is the entire game.

--- a/src/content/blog/trust-layer-agent-economy.md
+++ b/src/content/blog/trust-layer-agent-economy.md
@@ -1,0 +1,72 @@
+---
+title: When Your Customer Is an Agent, Who Do You Trust?
+publishDate: 2026-06-05
+img:
+img_alt:
+category: technology
+description: |
+  Autonomous agents are starting to pay each other on-chain. The protocols are mostly solved. The hard part—knowing who is worth transacting with—is the trust layer nobody has built yet.
+tags:
+  - Agentic AI
+  - Decentralized Identity
+  - Agent Payments
+  - Trust Infrastructure
+---
+
+## The Plumbing Is Done. The Trust Isn't.
+
+For the last year the conversation around agentic commerce has been about plumbing. How do agents pay each other? [x402](https://www.x402.org/) resurrected the dormant HTTP 402 status code into a stablecoin payment protocol, won itself a Linux Foundation home, and pulled in basically everyone who matters—Visa, Mastercard, Stripe, Google, AWS, Coinbase, Circle. Google's AP2 adopted x402 as its crypto rail rather than competing with it. The standards war is effectively over.
+
+So we can now make an agent pay another agent for an API call without a human in the loop. Great. Here is the question almost nobody is answering: **how does the buyer agent know the seller is any good?**
+
+That sounds small. It is the entire game.
+
+## A Decade of Watching Identity Marketplaces Die
+
+I have a particular allergy to this problem because I have watched its cousin fail repeatedly. Years ago, during my graduate work in information security, I wrote a [white paper on decentralized access control](/work/decentralized-access-control)—the idea that users should own their identities outright rather than renting trust from whoever happens to operate the server. The motivating realization was uncomfortable: while running the backend for an access control startup, I could impersonate any user in our system and quietly rewrite the logs. The whole edifice rested on trusting the operator.
+
+The decentralized-identity world's answer was Verifiable Credentials and DIDs—cryptographically signed claims that you carry and present yourself. Beautiful primitives. And for human identity, they mostly died on the vine. Not because the cryptography was wrong, but because of **cold-start**. Nobody issues credentials before anybody verifies them, verifiers won't pay for coverage that doesn't exist yet, and everyone stalls in a standoff waiting for the other side to move first.
+
+I bring this up because the agent economy quietly breaks that standoff, and most people haven't noticed why.
+
+## The Chain Is a Free, Tamper-Evident Behavioral Record
+
+Here is the thing that makes agent reputation genuinely different from human reputation: **agents settle on-chain.** Every payment, every counterparty, every success and failure is publicly observable. You don't need a two-sided marketplace where issuers and verifiers politely wait for each other. The behavioral substrate already exists, it's free, and it's tamper-evident by construction.
+
+For the first time, you can bootstrap a reputation graph by *mining what already happened* instead of begging a network into existence. That is a structural escape hatch from the cold-start trap that buried a decade of identity ventures. It genuinely excites me.
+
+But—and this is where I want to be the person who tells you the unsexy truth—the chain only sees half of what matters.
+
+## The Quantity/Quality Gap Nobody Wants to Talk About
+
+On-chain data tells you *quantity*. How much did this endpoint settle? With how many distinct counterparties? How old is the wallet? What's the refund rate? Real signal, all of it.
+
+What the chain cannot tell you is *quality*. **Did the API actually return good data?** Was the response correct, or was it confidently wrong? The settlement event fires the moment money moves—the protocol is "settle-and-done" by design, and the chain can't roll back a delivered HTTP response. So the single most important question—*was this service any good?*—lives entirely off-chain.
+
+This matters because the easy, seductive version of agent reputation is "count the transactions and rank them." And counting transactions is *exactly* what an adversary optimizes against. At its peak, something like half of all x402 volume was wash-trading—wallets paying themselves to manufacture the appearance of activity. The adversary isn't hypothetical and arriving later. **The adversary is already here, and it showed up before the legitimate customers did.**
+
+Any reputation system that scores volume is scoring the precise thing fraud is best at faking. The hard, valuable work is everything the chain doesn't give you for free: clustering sybil wallets, fingerprinting spam farms, and—the part that costs real money—actually probing services to see if they deliver. Quality measurement is adversarial security operations, not a database query. Anyone who tells you on-chain data alone solves agent trust is selling the easy half.
+
+## Reputation You Own vs. Reputation You Rent
+
+Now the part that pulls my two careers together. Suppose you do build a credible trust signal. Where does it live?
+
+Today the most sophisticated scorer in the space is Coinbase's Bazaar, and its reputation score is *walled*—computed internally, never exposed to the caller, applied only to traffic that routes through Coinbase. That is reputation you rent. It works inside one castle and evaporates the moment you step outside it.
+
+This is the same mistake the centralized identity world made, and it's exactly the failure mode my white paper was reacting to. A trust score that a single rail owner controls is a trust score that serves the rail owner. The instant an agent transacts across a different rail—x402 here, AP2 there, something not yet invented next year—a vendor-locked score is worthless.
+
+The version that actually matters is **portable**: a signed attestation the agent carries with it across rails and platforms, verifiable by anyone, owned by no one. This is, after a decade, finally the *right* application for Verifiable Credentials and DIDs. Not because the buzzwords aged well, but because the agent economy produces the one thing human identity never could—an objective behavioral history worth attaching to a portable, self-controlled identifier. The primitive was waiting for the right substrate the whole time.
+
+And notably, no single rail owner can credibly build this, because neutrality is the product. Coinbase won't trust Google's scores and Google won't trust Coinbase's. Cross-rail trust has to come from someone who isn't a rail.
+
+## The Chicken-and-Egg That Defines the Whole Opportunity
+
+I want to close honestly, because thought leadership that only sells the upside isn't leadership.
+
+Real, non-synthetic agent commerce is still *tiny*—on the order of tens of thousands of dollars a day, with average payments around twenty cents. Reputation matters in proportion to value-at-risk, and right now the value at risk per decision is pocket change. Nobody underwrites a twenty-cent loan.
+
+So we have a genuine chicken-and-egg: **high-value autonomous commerce won't happen until trust infrastructure exists, and trust infrastructure can't sustain itself until high-value commerce exists.** That tension is the most important fact in the entire space, and it cuts both ways. It's the reason this is hard. It's also the reason it's interesting—whoever builds the trust layer isn't just serving the market, they're a precondition for it existing at all. The catalyst and the customer are the same thing.
+
+The plumbing question—*how do agents pay?*—is solved. The question that decides whether any of it amounts to a real economy is older than blockchains, older than the internet: *when a stranger offers to transact, how do you know they're worth trusting?* We just have to answer it for counterparties that spin up in milliseconds, settle irreversibly, and lie about half the time.
+
+That's the layer I can't stop thinking about. The protocols were the easy part.

--- a/src/content/blog/trust-layer-agent-economy.md
+++ b/src/content/blog/trust-layer-agent-economy.md
@@ -1,5 +1,5 @@
 ---
-title: When Your Customer Is an Agent, Who Do You Trust?
+title: "x402: When Your Customer Is an Agent, Who Do You Trust?"
 publishDate: 2026-06-05
 img:
 img_alt:
@@ -7,8 +7,7 @@ category: technology
 description: |
   Autonomous agents are starting to pay each other on-chain. The protocols are mostly solved. The hard part, knowing who is worth transacting with, is the trust layer nobody has built yet.
 tags:
-  - Agentic AI
-  - Decentralized Identity
+  - Agent Identity
   - Agent Payments
   - Trust Infrastructure
 ---
@@ -23,7 +22,7 @@ That sounds small. It is the entire game.
 
 ## A Decade of Watching Identity Marketplaces Die
 
-I have a particular allergy to this problem because I have watched its cousin fail repeatedly. Years ago, during my graduate work in information security, I wrote a [white paper on decentralized access control](/work/decentralized-access-control), arguing that users should own their identities outright rather than renting trust from whoever happens to operate the server. The motivating realization was uncomfortable: while running the backend for an access control startup, I could impersonate any user in our system and quietly rewrite the logs. The whole edifice rested on trusting the operator.
+I have a particular allergy to this problem because I have watched its cousin fail repeatedly. Years ago, during my graduate work in information security, I wrote a [white paper on decentralized access control](/work/decentralized-access-control), arguing that users should own their identities outright rather than renting trust from whoever happens to operate the service. The motivating realization was uncomfortable: while running the platform for an access control startup, I could impersonate any user in our system, grant access, and quietly rewrite their audit trail. The whole edifice rested on trusting the operator.
 
 The decentralized-identity world's answer was Verifiable Credentials and DIDs, cryptographically signed claims that you carry and present yourself. Beautiful primitives. And for human identity, they mostly died on the vine. Not because the cryptography was wrong, but because of **cold-start**. Nobody issues credentials before anybody verifies them, verifiers won't pay for coverage that doesn't exist yet, and everyone stalls in a standoff waiting for the other side to move first.
 
@@ -31,19 +30,19 @@ I bring this up because the agent economy quietly breaks that standoff, and most
 
 ## The Chain Is a Free, Tamper-Evident Behavioral Record
 
-Here is the thing that makes agent reputation genuinely different from human reputation: **agents settle on-chain.** Every payment, every counterparty, every success and failure is publicly observable. You don't need a two-sided marketplace where issuers and verifiers politely wait for each other. The behavioral substrate already exists, it's free, and it's tamper-evident by construction.
+Here is the thing that makes agent reputation genuinely different from human reputation: **agents can easily settle on-chain.** Every payment, every counterparty, every success and failure is publicly observable. You don't need a two-sided marketplace where issuers and verifiers politely wait for each other. The behavioral substrate already exists, it's free, and it's tamper-evident by construction.
 
-For the first time, you can bootstrap a reputation graph by *mining what already happened* instead of begging a network into existence. That is a structural escape hatch from the cold-start trap that buried a decade of identity ventures. It genuinely excites me.
+For the first time, you can bootstrap a reputation graph by _mining what already happened_ instead of begging a network into existence. That is a structural escape hatch from the cold-start trap that buried a decade of identity ventures. It genuinely excites me.
 
 But the chain only sees half of what matters, and this is where I want to be the person who tells you the unsexy truth.
 
 ## The Quantity/Quality Gap Nobody Wants to Talk About
 
-On-chain data tells you *quantity*. How much did this endpoint settle? With how many distinct counterparties? How old is the wallet? What's the refund rate? Real signal, all of it.
+On-chain data tells you _quantity_. How much did this endpoint settle? With how many distinct counterparties? How old is the wallet? What's the refund rate? Real signal, all of it.
 
-What the chain cannot tell you is *quality*. **Did the API actually return good data?** Was the response correct, or was it confidently wrong? The settlement event fires the moment money moves. The protocol is "settle-and-done" by design, and the chain can't roll back a delivered HTTP response. So the single most important question, *was this service any good?*, lives entirely off-chain.
+What the chain cannot tell you is _quality_. **Did the API actually return good data?** Was the response correct, or was it confidently wrong? The settlement event fires the moment money moves. The protocol is "settle-and-done" by design, and the chain can't roll back a delivered HTTP response. So the single most important question, _was this service any good?_, lives entirely off-chain.
 
-This matters because the easy, seductive version of agent reputation is "count the transactions and rank them." And counting transactions is *exactly* what an adversary optimizes against. At its peak, something like half of all x402 volume was wash-trading: wallets paying themselves to manufacture the appearance of activity. The adversary isn't hypothetical and arriving later. **The adversary is already here, and it showed up before the legitimate customers did.**
+This matters because the easy, seductive version of agent reputation is "count the transactions and rank them." And counting transactions is _exactly_ what an adversary optimizes against. At its peak, something like half of all x402 volume was wash-trading: wallets paying themselves to manufacture the appearance of activity. The adversary isn't hypothetical and arriving later. **The adversary is already here, and it showed up before the legitimate customers did.**
 
 Any reputation system that scores volume is scoring the precise thing fraud is best at faking. The hard, valuable work is everything the chain doesn't give you for free: clustering sybil wallets, fingerprinting spam farms, and the part that costs real money, actually probing services to see if they deliver. Quality measurement is adversarial security operations, not a database query. Anyone who tells you on-chain data alone solves agent trust is selling the easy half.
 
@@ -51,11 +50,11 @@ Any reputation system that scores volume is scoring the precise thing fraud is b
 
 Now the part that pulls my two careers together. Suppose you do build a credible trust signal. Where does it live?
 
-Today the most sophisticated scorer in the space is Coinbase's Bazaar, and its reputation score is *walled*. It's computed internally, never exposed to the caller, applied only to traffic that routes through Coinbase. That is reputation you rent. It works inside one castle and evaporates the moment you step outside it.
+Today the most sophisticated scorer in the space is Coinbase's Bazaar, and its reputation score is _walled_. It's computed internally, never exposed to the caller, applied only to traffic that routes through Coinbase. That is reputation you rent. It works inside one castle and evaporates the moment you step outside it.
 
 This is the same mistake the centralized identity world made, and it's exactly the failure mode my white paper was reacting to. A trust score that a single rail owner controls is a trust score that serves the rail owner. The instant an agent transacts across a different rail, x402 here, AP2 there, something not yet invented next year, a vendor-locked score is worthless.
 
-The version that actually matters is **portable**: a signed attestation the agent carries with it across rails and platforms, verifiable by anyone, owned by no one. This is, after a decade, finally the *right* application for Verifiable Credentials and DIDs. Not because the buzzwords aged well, but because the agent economy produces the one thing human identity never could, an objective behavioral history worth attaching to a portable, self-controlled identifier. The primitive was waiting for the right substrate the whole time.
+The version that actually matters is **portable**: a signed attestation the agent carries with it across rails and platforms, verifiable by anyone, owned by no one. This is, after a decade, finally the _right_ application for Verifiable Credentials and DIDs. Not because the buzzwords aged well, but because the agent economy produces the one thing human identity never could, an objective behavioral history worth attaching to a portable, self-controlled identifier. The primitive was waiting for the right substrate the whole time.
 
 And notably, no single rail owner can credibly build this, because neutrality is the product. Coinbase won't trust Google's scores and Google won't trust Coinbase's. Cross-rail trust has to come from someone who isn't a rail.
 
@@ -63,10 +62,10 @@ And notably, no single rail owner can credibly build this, because neutrality is
 
 I want to close honestly, because thought leadership that only sells the upside isn't leadership.
 
-Real, non-synthetic agent commerce is still *tiny*, on the order of tens of thousands of dollars a day, with average payments around twenty cents. Reputation matters in proportion to value-at-risk, and right now the value at risk per decision is pocket change. Nobody underwrites a twenty-cent loan.
+Real, non-synthetic agent commerce is still _tiny_, on the order of tens of thousands of dollars a day, with average payments around twenty cents. Reputation matters in proportion to value-at-risk, and right now the value at risk per decision is pocket change. Nobody underwrites a twenty-cent loan.
 
 So we have a genuine chicken-and-egg: **high-value autonomous commerce won't happen until trust infrastructure exists, and trust infrastructure can't sustain itself until high-value commerce exists.** That tension is the most important fact in the entire space, and it cuts both ways. It's the reason this is hard. It's also the reason it's interesting: whoever builds the trust layer isn't just serving the market, they're a precondition for it existing at all. The catalyst and the customer are the same thing.
 
-The plumbing question, *how do agents pay?*, is solved. The question that decides whether any of it amounts to a real economy is older than blockchains, older than the internet: *when a stranger offers to transact, how do you know they're worth trusting?* We just have to answer it for counterparties that spin up in milliseconds, settle irreversibly, and lie about half the time.
+The plumbing question, _how do agents pay?_, is solved. The question that decides whether any of it amounts to a real economy is older than blockchains, older than the internet: _when a stranger offers to transact, how do you know they're worth trusting?_ We just have to answer it for counterparties that spin up in milliseconds, settle irreversibly, and lie about half the time.
 
-That's the layer I can't stop thinking about. The protocols were the easy part.
+This the layer that my I can't help but think my years of building identity systems makes me uniquely tailored to tackle. Is this space viability ready to build a business in?

--- a/src/content/blog/trust-layer-agent-economy.md
+++ b/src/content/blog/trust-layer-agent-economy.md
@@ -54,7 +54,7 @@ Today the most sophisticated scorer in the space is Coinbase's Bazaar, and its r
 
 This is the same mistake the centralized identity world made, and it's exactly the failure mode my white paper was reacting to. A trust score that a single rail owner controls is a trust score that serves the rail owner. The instant an agent transacts across a different rail, x402 here, AP2 there, something not yet invented next year, a vendor-locked score is worthless.
 
-The version that actually matters is **portable**: a signed attestation the agent carries with it across rails and platforms, verifiable by anyone, owned by no one. This is, after a decade, finally the _right_ application for Verifiable Credentials and DIDs. Not because the buzzwords aged well, but because the agent economy produces the one thing human identity never could, an objective behavioral history worth attaching to a portable, self-controlled identifier. The primitive was waiting for the right substrate the whole time.
+The version that actually matters is **portable**: a signed attestation the agent carries with it across rails and platforms, verifiable by anyone, owned by no one. This is, after a decade, finally the _right_ application for Verifiable Credentials and DIDs. Not because the buzzwords aged well, but because the agent economy produces the one thing human identity never could—an objective behavioral history worth attaching to a portable, self-controlled identifier. The primitive was waiting for the right substrate the whole time.
 
 And notably, no single rail owner can credibly build this, because neutrality is the product. Coinbase won't trust Google's scores and Google won't trust Coinbase's. Cross-rail trust has to come from someone who isn't a rail.
 
@@ -68,4 +68,4 @@ So we have a genuine chicken-and-egg: **high-value autonomous commerce won't hap
 
 The plumbing question, _how do agents pay?_, is solved. The question that decides whether any of it amounts to a real economy is older than blockchains, older than the internet: _when a stranger offers to transact, how do you know they're worth trusting?_ We just have to answer it for counterparties that spin up in milliseconds, settle irreversibly, and lie about half the time.
 
-This the layer that my I can't help but think my years of building identity systems makes me uniquely tailored to tackle. Is this space viability ready to build a business in?
+This is the layer my years of building identity systems have uniquely prepared me to tackle. Whether the space is viable enough to build a business in yet—that is the harder question.

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -42,8 +42,10 @@ const hasCitations = rawContent.includes('citation:');
 							<div class="tags">
 								{entry.data.tags.map((t: string) => <Pill>{t}</Pill>)}
 							</div>
-							<p class="description">{entry.data.description}</p>
-                            <p class="date">{new Date(entry.data.publishDate).toISOString().split('T')[0]}</p>
+							<div class="details-row">
+								<p class="description">{entry.data.description}</p>
+								<p class="date">{new Date(entry.data.publishDate).toISOString().split('T')[0]}</p>
+							</div>
 						</div>
 					</Hero>
 				</div>
@@ -80,14 +82,35 @@ const hasCitations = rawContent.includes('citation:');
 		align-items: center;
 	}
 
+	/* Description + date share a row on desktop; date must never wrap. */
+	.details-row {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		align-items: center;
+	}
+
 	.tags {
 		display: flex;
+		flex-wrap: wrap;
 		gap: 0.5rem;
+		justify-content: center;
 	}
 
 	.description {
 		font-size: var(--text-lg);
 		max-width: 54ch;
+		text-align: center;
+		margin: 0;
+	}
+
+	.date {
+		font-size: var(--text-lg);
+		color: var(--gray-300);
+		margin: 0;
+		/* ISO dates (2026-06-05) must stay on one line even in tight flex layouts */
+		white-space: nowrap;
+		flex-shrink: 0;
 	}
 
 	.content {
@@ -207,7 +230,29 @@ const hasCitations = rawContent.includes('citation:');
 
 		.details {
 			flex-direction: row;
+			align-items: flex-start;
 			gap: 2.5rem;
+		}
+
+		.tags {
+			justify-content: flex-start;
+		}
+
+		.details-row {
+			flex: 1;
+			flex-direction: row;
+			justify-content: space-between;
+			align-items: baseline;
+			gap: 2rem;
+		}
+
+		.description {
+			flex: 1;
+			text-align: left;
+		}
+
+		.date {
+			text-align: right;
 		}
 
 		.content :global(blockquote) {


### PR DESCRIPTION
## Summary
- Adds a new blog post on x402, agent-to-agent payments, and the missing trust layer for the agent economy.
- Contrasts x402 with MCP (connectivity vs. settlement) and argues portable reputation is the hard, valuable problem.
- Fixes blog post header layout so publish dates stay on a single line.

## Test plan
- [ ] Run `npm run build` and confirm the site builds without errors
- [ ] Open `/blog/trust-layer-agent-economy/` and verify title, tags, description, and date layout
- [ ] Confirm the MCP cross-link resolves to `/blog/mcp/`
- [ ] Spot-check prose and formatting on mobile and desktop viewports


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content and presentational layout/CSS only; no auth, data, or build-pipeline logic changes beyond standard Astro content collection routing.
> 
> **Overview**
> Adds a new essay **`trust-layer-agent-economy`** on x402, agent micropayments, and why **portable trust/reputation** (not payment rails) is the open problem—contrasting settlement with MCP-style connectivity and linking to existing `/blog/mcp/` and work pages.
> 
> Updates the **blog post header** in `[...slug].astro`: description and publish date sit in a new **`details-row`** flex block so tags can wrap and, on wide viewports, description and date share one row with the **ISO date forced to a single line** (`white-space: nowrap`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f80607e3ba649e277db01ee3b295d1f2e3e9a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->