### PR TITLE
feat(ui): futuristic cyberpunk redesign with neon cyan palette

### DIFF
--- a/src/components/CallToAction.astro
+++ b/src/components/CallToAction.astro
@@ -21,15 +21,42 @@ const { href } = Astro.props;
 		line-height: 1.1;
 		border-radius: 999rem;
 		overflow: hidden;
+		/* Cyberpunk gradient: cyan → violet */
 		background: var(--gradient-accent-orange);
-		box-shadow: var(--shadow-md);
+		background-size: 200% 200%;
+		box-shadow: var(--glow-sm), var(--shadow-md);
 		white-space: nowrap;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		font-family: var(--font-brand);
+		font-weight: 600;
+		transition:
+			box-shadow var(--theme-transition),
+			transform var(--theme-transition),
+			background-position var(--theme-transition);
+		animation: gradient-shift 4s ease infinite;
 	}
 
 	@media (min-width: 20em) {
 		a {
-			font-size: var(--text-lg);
+			font-size: var(--text-md);
 		}
+	}
+
+	/* Scanline overlay */
+	a::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		background: repeating-linear-gradient(
+			0deg,
+			transparent,
+			transparent 2px,
+			rgba(0, 0, 0, 0.05) 2px,
+			rgba(0, 0, 0, 0.05) 4px
+		);
+		z-index: 1;
 	}
 
 	/* Overlay for hover effects. */
@@ -40,6 +67,13 @@ const { href } = Astro.props;
 		pointer-events: none;
 		transition: background-color var(--theme-transition);
 		mix-blend-mode: overlay;
+		z-index: 2;
+	}
+
+	a:focus,
+	a:hover {
+		box-shadow: var(--glow-md), var(--shadow-md);
+		transform: translateY(-1px);
 	}
 
 	a:focus::after,
@@ -50,7 +84,7 @@ const { href } = Astro.props;
 	@media (min-width: 50em) {
 		a {
 			padding: 1.125rem 2.5rem;
-			font-size: var(--text-xl);
+			font-size: var(--text-lg);
 		}
 	}
 </style>

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -17,17 +17,42 @@ import Icon from './Icon.astro';
 		flex-direction: column;
 		align-items: center;
 		gap: 3rem;
-		border-top: 1px solid var(--gray-800);
-		border-bottom: 1px solid var(--gray-800);
+		border-top: 1px solid var(--accent-overlay);
+		border-bottom: 1px solid var(--accent-overlay);
 		padding: 5rem 1.5rem;
-		background-color: var(--gray-999_40);
-		box-shadow: var(--shadow-sm);
+		/* Glassmorphism CTA section */
+		background-color: hsla(var(--gray-999-basis), 0.4);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
+		box-shadow: inset 0 1px 0 var(--accent-overlay), var(--glow-sm);
+		position: relative;
+		overflow: hidden;
+	}
+
+	/* Subtle horizontal scan-line decoration */
+	aside::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		background: repeating-linear-gradient(
+			0deg,
+			transparent,
+			transparent 4px,
+			var(--accent-overlay) 4px,
+			var(--accent-overlay) 5px
+		);
+		opacity: 0.15;
 	}
 
 	h2 {
 		font-size: var(--text-xl);
 		text-align: center;
 		max-width: 15ch;
+		color: var(--accent-dark);
+		letter-spacing: 0.03em;
+		position: relative;
+		z-index: 1;
 	}
 
 	@media (min-width: 50em) {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -10,7 +10,7 @@ const { align = 'center', tagline, title } = Astro.props;
 
 <div class:list={['hero stack gap-4', align]}>
 	<div class="stack gap-2">
-		<h1 class="title">{title}</h1>
+		<h1 class="title gradient-text">{title}</h1>
 		{tagline && <p class="tagline">{tagline}</p>}
 	</div>
 	<slot />
@@ -31,6 +31,37 @@ const { align = 'center', tagline, title } = Astro.props;
 	.title {
 		font-size: var(--text-3xl);
 		color: var(--gray-0);
+	}
+
+	/* Animated gradient text for the hero title */
+	.gradient-text {
+		background: linear-gradient(
+			270deg,
+			var(--accent-light),
+			var(--accent-regular),
+			#7c3aed,
+			var(--accent-dark),
+			var(--accent-light)
+		);
+		background-size: 300% 300%;
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+		animation: gradient-shift var(--gradient-animation-duration) ease infinite;
+	}
+
+	/* Fallback for browsers without gradient text support */
+	@supports not (-webkit-background-clip: text) {
+		.gradient-text {
+			color: var(--accent-regular);
+			background: none;
+			animation: none;
+		}
+	}
+
+	.tagline {
+		color: var(--gray-300);
+		letter-spacing: 0.01em;
 	}
 
 	@media (min-width: 50em) {

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -24,7 +24,7 @@ const {
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-	href="https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,400;0,700;1,400&family=Rubik:wght@500;600&display=swap"
+	href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;900&family=Public+Sans:ital,wght@0,400;0,700;1,400&family=Rubik:wght@500;600&display=swap"
 	rel="stylesheet"
 />
 <script is:inline>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -172,8 +172,18 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 		gap: 0.5rem;
 		align-items: center;
 		line-height: 1.1;
-		color: var(--gray-0);
+		color: var(--accent-dark);
 		text-decoration: none;
+		font-size: var(--text-base);
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		transition: color var(--theme-transition), text-shadow var(--theme-transition);
+	}
+
+	.site-title:hover,
+	.site-title:focus {
+		color: var(--accent-regular);
+		text-shadow: var(--glow-text);
 	}
 
 	.menu-button {
@@ -183,15 +193,21 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 		border-radius: 999rem;
 		padding: 0.5rem;
 		font-size: 1.5rem;
-		color: var(--gray-300);
+		color: var(--accent-regular);
 		background: radial-gradient(var(--gray-900), var(--gray-800) 150%);
 		box-shadow: var(--shadow-md);
+		transition: box-shadow var(--theme-transition);
+	}
+
+	.menu-button:hover {
+		box-shadow: var(--glow-sm);
 	}
 
 	.menu-button[aria-expanded='true'] {
-		color: var(--gray-0);
+		color: var(--accent-dark);
 		background: linear-gradient(180deg, var(--gray-600), transparent),
 			radial-gradient(var(--gray-900), var(--gray-800) 150%);
+		box-shadow: var(--glow-sm);
 	}
 
 	.menu-button[hidden] {
@@ -202,9 +218,10 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 		position: absolute;
 		inset: -1px;
 		content: '';
-		background: var(--gradient-stroke);
+		background: linear-gradient(180deg, var(--accent-regular), var(--accent-dark));
 		border-radius: 999rem;
 		z-index: -1;
+		opacity: 0.6;
 	}
 
 	.menu-content {
@@ -222,18 +239,26 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 		line-height: 1.2;
 		list-style: none;
 		padding: 2rem;
-		background-color: var(--gray-999);
-		border-bottom: 1px solid var(--gray-800);
+		/* Glassmorphism mobile menu */
+		background-color: hsla(var(--gray-999-basis), 0.85);
+		backdrop-filter: blur(12px);
+		-webkit-backdrop-filter: blur(12px);
+		border-bottom: 1px solid var(--accent-overlay);
 	}
 
 	.link {
 		display: inline-block;
 		color: var(--gray-300);
 		text-decoration: none;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		font-size: var(--text-sm);
+		transition: color var(--theme-transition), text-shadow var(--theme-transition);
 	}
 
 	.link.active {
-		color: var(--gray-0);
+		color: var(--accent-dark);
+		text-shadow: var(--glow-text);
 	}
 
 	.menu-footer {
@@ -244,9 +269,13 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 		justify-content: space-between;
 		gap: 0.75rem;
 		padding: 1.5rem 2rem 1.5rem 1.5rem;
-		background-color: var(--gray-999);
+		background-color: hsla(var(--gray-999-basis), 0.85);
+		backdrop-filter: blur(12px);
+		-webkit-backdrop-filter: blur(12px);
 		border-radius: 0 0 0.75rem 0.75rem;
-		box-shadow: var(--shadow-lg);
+		border: 1px solid var(--accent-overlay);
+		border-top: none;
+		box-shadow: var(--glow-sm);
 	}
 
 	.socials {
@@ -260,13 +289,14 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 		display: flex;
 		padding: var(--icon-padding);
 		text-decoration: none;
-		color: var(--accent-dark);
-		transition: color var(--theme-transition);
+		color: var(--accent-regular);
+		transition: color var(--theme-transition), filter var(--theme-transition);
 	}
 
 	.social:hover,
 	.social:focus {
-		color: var(--accent-text-over);
+		color: var(--accent-dark);
+		filter: drop-shadow(0 0 6px var(--accent-regular));
 	}
 
 	.theme-toggle {
@@ -289,7 +319,7 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 		}
 
 		.site-title {
-			font-size: var(--text-lg);
+			font-size: var(--text-base);
 		}
 
 		.menu-content {
@@ -301,19 +331,17 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			flex-direction: row;
 			font-size: var(--text-sm);
 			border-radius: 999rem;
-			border: 0;
+			border: 1px solid var(--accent-overlay);
 			padding: 0.5rem 0.5625rem;
-			background: radial-gradient(var(--gray-900), var(--gray-800) 150%);
-			box-shadow: var(--shadow-md);
+			/* Glassmorphism pill nav */
+			background: hsla(var(--gray-999-basis), 0.6);
+			backdrop-filter: blur(16px);
+			-webkit-backdrop-filter: blur(16px);
+			box-shadow: var(--glow-sm), var(--shadow-md);
 		}
 
 		.nav-items::before {
-			position: absolute;
-			inset: -1px;
-			content: '';
-			background: var(--gradient-stroke);
-			border-radius: 999rem;
-			z-index: -1;
+			display: none;
 		}
 
 		.link {
@@ -321,18 +349,21 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			border-radius: 999rem;
 			transition:
 				color var(--theme-transition),
-				background-color var(--theme-transition);
+				background-color var(--theme-transition),
+				text-shadow var(--theme-transition);
 		}
 
 		.link:hover,
 		.link:focus {
-			color: var(--gray-100);
+			color: var(--accent-dark);
 			background-color: var(--accent-subtle-overlay);
 		}
 
 		.link.active {
 			color: var(--accent-text-over);
 			background-color: var(--accent-regular);
+			text-shadow: none;
+			box-shadow: var(--glow-sm);
 		}
 
 		.menu-footer {
@@ -342,6 +373,9 @@ const iconLinks: { label: string; href: string; icon: keyof typeof iconPaths }[]
 			align-items: center;
 			padding: 0;
 			background-color: transparent;
+			backdrop-filter: none;
+			-webkit-backdrop-filter: none;
+			border: none;
 			box-shadow: none;
 		}
 

--- a/src/components/Pill.astro
+++ b/src/components/Pill.astro
@@ -5,12 +5,24 @@
 		display: flex;
 		padding: 0.5rem 1rem;
 		gap: 0.5rem;
-		color: var(--accent-text-over);
+		color: var(--accent-dark);
+		/* Outlined/glowing pill — no solid fill */
 		border: 1px solid var(--accent-regular);
-		background-color: var(--accent-regular);
+		background-color: var(--accent-overlay);
 		border-radius: 999rem;
 		font-size: var(--text-md);
+		font-family: var(--font-brand);
+		font-weight: 500;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
 		line-height: 1.35;
 		white-space: nowrap;
+		box-shadow: var(--glow-sm);
+		transition: box-shadow var(--theme-transition), border-color var(--theme-transition);
+	}
+
+	.pill:hover {
+		box-shadow: var(--glow-md);
+		border-color: var(--accent-dark);
 	}
 </style>

--- a/src/components/PortfolioPreview.astro
+++ b/src/components/PortfolioPreview.astro
@@ -19,7 +19,7 @@ const { data, slug } = Astro.props.project;
 		grid-template: auto 1fr / auto 1fr;
 		height: 11rem;
 		background: var(--gradient-subtle);
-		border: 1px solid var(--gray-800);
+		border: 1px solid var(--accent-overlay);
 		border-radius: 0.75rem;
 		overflow: hidden;
 		box-shadow: var(--shadow-sm);
@@ -27,11 +27,16 @@ const { data, slug } = Astro.props.project;
 		font-family: var(--font-brand);
 		font-size: var(--text-lg);
 		font-weight: 500;
-		transition: box-shadow var(--theme-transition);
+		transition:
+			box-shadow var(--theme-transition),
+			border-color var(--theme-transition),
+			transform var(--theme-transition);
 	}
 
 	.card:hover {
-		box-shadow: var(--shadow-md);
+		box-shadow: var(--glow-md);
+		border-color: var(--accent-regular);
+		transform: translateY(-2px);
 	}
 
 	.title {
@@ -39,9 +44,23 @@ const { data, slug } = Astro.props.project;
 		z-index: 1;
 		margin: 0.5rem;
 		padding: 0.5rem 1rem;
-		background: var(--gray-999);
-		color: var(--gray-200);
+		/* Glassmorphism title badge */
+		background: hsla(var(--gray-999-basis), 0.75);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
+		color: var(--accent-dark);
+		border: 1px solid var(--accent-overlay);
 		border-radius: 0.375rem;
+		letter-spacing: 0.03em;
+		text-transform: uppercase;
+		font-size: var(--text-sm);
+		transition: color var(--theme-transition), border-color var(--theme-transition), box-shadow var(--theme-transition);
+	}
+
+	.card:hover .title {
+		color: var(--accent-regular);
+		border-color: var(--accent-regular);
+		box-shadow: var(--glow-sm);
 	}
 
 	img {

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -25,11 +25,20 @@ import Icon from './Icon.astro';
 
 <style>
 	.box {
-		border: 1px solid var(--gray-800);
+		border: 1px solid var(--accent-overlay);
 		border-radius: 0.75rem;
 		padding: 1.5rem;
-		background-color: var(--gray-999_40);
-		box-shadow: var(--shadow-sm);
+		/* Glassmorphism */
+		background-color: hsla(var(--gray-999-basis), 0.55);
+		backdrop-filter: blur(12px);
+		-webkit-backdrop-filter: blur(12px);
+		box-shadow: var(--glow-sm), var(--shadow-sm);
+		transition: box-shadow var(--theme-transition), border-color var(--theme-transition);
+	}
+
+	.box:hover {
+		border-color: var(--accent-regular);
+		box-shadow: var(--glow-md);
 	}
 
 	.skills {
@@ -40,10 +49,18 @@ import Icon from './Icon.astro';
 
 	.skills h2 {
 		font-size: var(--text-lg);
+		color: var(--accent-dark);
+		letter-spacing: 0.03em;
+		text-transform: uppercase;
 	}
 
 	.skills p {
 		color: var(--gray-400);
+	}
+
+	/* Icon glow on hover */
+	.skills .stack:hover :global(svg) {
+		filter: drop-shadow(0 0 8px var(--accent-regular));
 	}
 
 	@media (min-width: 50em) {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -107,6 +107,25 @@ const { title, description } = Astro.props;
 					/*header2*/ normal,
 					/*base*/ normal;
 			}
+
+			/* Futuristic grid overlay — subtle cyan mesh on dark, barely-there on light */
+			.backgrounds::after {
+				content: '';
+				position: fixed;
+				inset: 0;
+				pointer-events: none;
+				z-index: 0;
+				background-image:
+					linear-gradient(rgba(6, 182, 212, 0.04) 1px, transparent 1px),
+					linear-gradient(90deg, rgba(6, 182, 212, 0.04) 1px, transparent 1px);
+				background-size: 60px 60px;
+			}
+
+			:global(.theme-dark) .backgrounds::after {
+				background-image:
+					linear-gradient(rgba(34, 211, 238, 0.06) 1px, transparent 1px),
+					linear-gradient(90deg, rgba(34, 211, 238, 0.06) 1px, transparent 1px);
+			}
 			@media (forced-colors: active) {
 				/* Deactivate custom backgrounds for high contrast users. */
 				.backgrounds {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,14 +16,15 @@
 	--gray-999_40: hsla(var(--gray-999-basis), 0.4);
 	--gray-999: #ffffff;
 
-	--accent-light: #c561f6;
-	--accent-regular: #7611a6;
-	--accent-dark: #1c0056;
-	--accent-overlay: hsla(280, 89%, 67%, 0.33);
+	/* Futuristic cyan/electric accent palette */
+	--accent-light: #a5f3fc;
+	--accent-regular: #06b6d4;
+	--accent-dark: #0891b2;
+	--accent-overlay: hsla(189, 94%, 43%, 0.25);
 	--accent-subtle-overlay: var(--accent-overlay);
 	--accent-text-over: var(--gray-999);
 
-	--link-color: var(--accent-regular);
+	--link-color: var(--accent-dark);
 
 	/* Gradients */
 	--gradient-stop-1: var(--accent-light);
@@ -36,15 +37,22 @@
 		var(--gradient-stop-2),
 		var(--gradient-stop-3)
 	);
+	/* Cyberpunk button gradient: cyan → violet */
 	--gradient-accent-orange: linear-gradient(
-		150deg,
-		#ca7879,
-		var(--accent-regular),
-		var(--accent-dark)
+		135deg,
+		#06b6d4,
+		#7c3aed,
+		#0e7490
 	);
 	--gradient-stroke: linear-gradient(180deg, var(--gray-900), var(--gray-700));
 
-	/* Shadows */
+	/* Neon glow effects */
+	--glow-sm: 0 0 8px rgba(6, 182, 212, 0.45);
+	--glow-md: 0 0 15px rgba(6, 182, 212, 0.55), 0 0 30px rgba(6, 182, 212, 0.25);
+	--glow-lg: 0 0 20px rgba(6, 182, 212, 0.65), 0 0 40px rgba(6, 182, 212, 0.35), 0 0 60px rgba(6, 182, 212, 0.15);
+	--glow-text: 0 0 10px rgba(6, 182, 212, 0.8), 0 0 20px rgba(6, 182, 212, 0.4);
+
+	/* Legacy shadow names (kept for compatibility, updated for futuristic look) */
 	--shadow-sm: 0px 6px 3px rgba(9, 11, 17, 0.01), 0px 4px 2px rgba(9, 11, 17, 0.01),
 		0px 2px 2px rgba(9, 11, 17, 0.02), 0px 0px 1px rgba(9, 11, 17, 0.03);
 	--shadow-md: 0px 28px 11px rgba(9, 11, 17, 0.01), 0px 16px 10px rgba(9, 11, 17, 0.03),
@@ -63,14 +71,17 @@
 	--text-4xl: 3.5rem;
 	--text-5xl: 4.5rem;
 
-	/* Fonts */
+	/* Fonts — Orbitron for the sci-fi brand feel */
 	--font-system: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
 		Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 	--font-body: 'Public Sans', var(--font-system);
-	--font-brand: Rubik, var(--font-system);
+	--font-brand: 'Orbitron', 'Rubik', var(--font-system);
 
 	/* Transitions */
 	--theme-transition: 0.2s ease-in-out;
+
+	/* Gradient text animation speed */
+	--gradient-animation-duration: 4s;
 }
 
 :root.theme-dark {
@@ -88,24 +99,31 @@
 	--gray-999-basis: 225, 31%, 5%;
 	--gray-999: #090b11;
 
-	--accent-light: #1c0056;
-	--accent-regular: #7611a6;
-	--accent-dark: #c561f6;
-	--accent-overlay: hsla(280, 89%, 67%, 0.33);
-	--accent-subtle-overlay: hsla(281, 81%, 36%, 0.33);
+	/* Dark mode: neon cyan pops against dark background */
+	--accent-light: #083344;
+	--accent-regular: #06b6d4;
+	--accent-dark: #22d3ee;
+	--accent-overlay: hsla(189, 94%, 43%, 0.3);
+	--accent-subtle-overlay: hsla(189, 94%, 43%, 0.15);
 	--accent-text-over: var(--gray-0);
 
 	--link-color: var(--accent-dark);
 
-	--gradient-stop-1: #4c11c6;
+	--gradient-stop-1: #0ea5e9;
 	--gradient-subtle: linear-gradient(150deg, var(--gray-900) 19%, var(--gray-999) 81%);
 	--gradient-accent-orange: linear-gradient(
-		150deg,
-		#ca7879,
-		var(--accent-regular),
-		var(--accent-light)
+		135deg,
+		#22d3ee,
+		#7c3aed,
+		#06b6d4
 	);
 	--gradient-stroke: linear-gradient(180deg, var(--gray-600), var(--gray-800));
+
+	/* Enhanced glows for dark mode */
+	--glow-sm: 0 0 10px rgba(34, 211, 238, 0.5);
+	--glow-md: 0 0 18px rgba(34, 211, 238, 0.6), 0 0 36px rgba(34, 211, 238, 0.3);
+	--glow-lg: 0 0 25px rgba(34, 211, 238, 0.7), 0 0 50px rgba(34, 211, 238, 0.4), 0 0 75px rgba(34, 211, 238, 0.15);
+	--glow-text: 0 0 12px rgba(34, 211, 238, 0.9), 0 0 25px rgba(34, 211, 238, 0.5);
 
 	--shadow-sm: 0px 6px 3px rgba(255, 255, 255, 0.01), 0px 4px 2px rgba(255, 255, 255, 0.01),
 		0px 2px 2px rgba(255, 255, 255, 0.02), 0px 0px 1px rgba(255, 255, 255, 0.03);
@@ -113,6 +131,38 @@
 		0px 7px 7px rgba(255, 255, 255, 0.05), 0px 2px 4px rgba(255, 255, 255, 0.06);
 	--shadow-lg: 0px 62px 25px rgba(255, 255, 255, 0.01), 0px 35px 21px rgba(255, 255, 255, 0.05),
 		0px 16px 16px rgba(255, 255, 255, 0.1), 0px 4px 9px rgba(255, 255, 255, 0.12);
+}
+
+/* ============================================================
+   Keyframe animations
+   ============================================================ */
+
+@keyframes gradient-shift {
+	0%   { background-position: 0% 50%; }
+	50%  { background-position: 100% 50%; }
+	100% { background-position: 0% 50%; }
+}
+
+@keyframes pulse-glow {
+	0%, 100% { box-shadow: var(--glow-sm); }
+	50%       { box-shadow: var(--glow-md); }
+}
+
+@keyframes border-glow-pulse {
+	0%, 100% { border-color: var(--accent-regular); }
+	50%       { border-color: var(--accent-dark); }
+}
+
+@keyframes scan-line {
+	0%   { transform: translateY(-100%); opacity: 0; }
+	10%  { opacity: 1; }
+	90%  { opacity: 1; }
+	100% { transform: translateY(100vh); opacity: 0; }
+}
+
+@keyframes flicker {
+	0%, 98%, 100% { opacity: 1; }
+	99%            { opacity: 0.85; }
 }
 
 html,
@@ -154,6 +204,7 @@ h5 {
 	font-family: var(--font-brand);
 	font-weight: 600;
 	color: var(--gray-100);
+	letter-spacing: 0.02em;
 }
 
 h1 {


### PR DESCRIPTION
## Summary

- **Neon cyan/electric palette** — replaces the existing purple accent system with a cyan (`#06b6d4`) + electric-violet gradient scheme; dark mode gets a brighter `#22d3ee` neon for maximum contrast
- **Orbitron font** — Google Fonts `Orbitron` loaded for all brand/heading typography, giving the signature sci-fi display feel
- **CSS glow variables + keyframe animations** — `--glow-sm/md/lg` box-shadow glow tokens and `gradient-shift`, `pulse-glow`, `scan-line` keyframes added globally
- **Animated gradient hero title** — hero `<h1>` uses `background-clip: text` with a shifting cyan → violet gradient animation
- **Glassmorphism nav** — navigation pill (desktop) and mobile menu use `backdrop-filter: blur(16px)` with semi-transparent backgrounds
- **Skills card** — glassmorphism box with glowing cyan border on hover; headings use uppercase + accent color
- **Portfolio preview cards** — glow border + subtle lift (`translateY(-2px)`) on hover; title badge uses glassmorphism overlay
- **Neon CTA button** — cyberpunk cyan-to-violet gradient with scanline texture overlay; glow intensifies on hover
- **Outlined/glowing Pill** — role badges switch from solid fill to outlined with `var(--accent-overlay)` tint and glow
- **ContactCTA section** — glassmorphism section with horizontal scanline texture pattern
- **Subtle grid overlay** — 60px CSS mesh grid in cyan tint layered over entire site background via `::after` pseudo-element

## Build & test results

```
astro check — 0 errors, 0 warnings, 0 hints (26 files)
astro build — 22 pages built in 3.37s ✓
```

## Decisions made

- **Cyan over purple**: Cyan/teal is the canonical "sci-fi HUD" color (Tron, Blade Runner, countless futuristic UIs). The original purple was more "whimsical"; cyan reads as technical and futuristic.
- **Glassmorphism cards**: `backdrop-filter: blur` requires the element to sit over the existing layered background images — this works with the site's `isolation: isolate` design.
- **Both themes updated**: Light theme gets a cleaner "holographic" cyan look; dark theme gets full neon glow treatment. The theme toggle still works perfectly.
- **Scanline overlays kept subtle**: `opacity: 0.05-0.15` so they add texture without hurting readability.
- **Orbitron weight range 400–900 loaded**: Covers all heading weights used site-wide.

## Agent notes

### What went well
- The site's existing CSS variable system made the color swap very clean — updating `--accent-*` in `global.css` cascaded everywhere automatically.
- Astro's scoped component styles meant each component could be upgraded independently without risk of cross-component leakage.
- `backdrop-filter` glassmorphism worked out of the box because the existing `BaseLayout` already sets `isolation: isolate` on `.backgrounds`.

### What was difficult
- `mise run build` wasn't available in the container (no tasks defined error). Fell back to `node_modules/.bin/astro check && astro build` after running `npm install`.
- `--glow-text` on gradient text doesn't render in Firefox (gradient `background-clip: text` hides `text-shadow`), so I used a `@supports` fallback for non-WebKit browsers.

### Patterns/conventions discovered
- CSS variables are the single source of truth — all theming is done via `:root` / `:root.theme-dark` in `global.css`. New design tokens fit naturally here.
- Component-scoped styles in Astro mean there's no global class collision risk; each `.astro` file owns its styles completely.
- The background system in `BaseLayout.astro` uses a stacked `background:` shorthand with blend modes — avoid adding new `background` properties to `.backgrounds` itself; use `::before`/`::after` pseudo-elements instead.
- The site uses `pnpm-lock.yaml` as its canonical lock file but `npm` works fine for CI since `package-lock.json` is also committed.

### Suggestions for future tasks
- Add a **typing/typewriter animation** to the hero tagline for extra sci-fi feel
- Consider a **particle/starfield canvas background** (lightweight, e.g. tsParticles) as an option in dark mode
- The **`ThemeToggle`** could be styled as a futuristic toggle switch (sliding indicator with glow) to match the new aesthetic
- A **loading splash screen** with a scan animation on first visit would complete the sci-fi HUD experience

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/krokoko/agent-plugins/blob/main/LICENSE).